### PR TITLE
修复中文搜索报错

### DIFF
--- a/src/1pass.py
+++ b/src/1pass.py
@@ -2,6 +2,9 @@
 
 import json
 import os
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 from Alfred import Items, Tools
 


### PR DESCRIPTION
中文搜索报错如下：
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe8 in position 0: ordinal not in range(128)